### PR TITLE
Improve performance with DataFrameWrapper indexes

### DIFF
--- a/orca_test/orca_test.py
+++ b/orca_test/orca_test.py
@@ -453,7 +453,7 @@ def get_column_or_index(table_name, column_name):
     t = orca.get_table(table_name)
     
     if column_name in t.index.names:
-    	return t.index.get_level_values(column_name).to_series()
+        return t.index.get_level_values(column_name).to_series()
     else:
         return t.get_column(column_name)
     

--- a/orca_test/orca_test.py
+++ b/orca_test/orca_test.py
@@ -453,7 +453,7 @@ def get_column_or_index(table_name, column_name):
     t = orca.get_table(table_name)
     
     if column_name in t.index.names:
-        return t.to_frame([]).reset_index()[column_name]
+    	return t.index.get_level_values(column_name).to_series()
     else:
         return t.get_column(column_name)
     


### PR DESCRIPTION
This addresses the bug in Issue #16. 

Instead of getting DataFrameWrapper indexes using `to_frame()`, now we use 

`DataFrameWrapper.index.get_level_values(column_name)`

which works for both normal indexes and multi-indexes. 

@fscottfoti - Could you try this branch with Bay Area UrbanSim and see if it solves the performance issues?

@Eh2406 - If convenient, could you try it with one of your multi-index use cases just to double-check that it doesn't cause any problems?