### PR TITLE
add is_unique assertion

### DIFF
--- a/orca_test/orca_test.py
+++ b/orca_test/orca_test.py
@@ -417,8 +417,6 @@ def assert_column_is_unique(table_name, column_name):
     
     ds = get_column_or_index(table_name, column_name)
     
-    print(ds)
-    
     if len(ds.unique()) != len(ds):
         msg = "Column '%s' does not have unique values" \
                 % (column_name)

--- a/orca_test/orca_test.py
+++ b/orca_test/orca_test.py
@@ -191,6 +191,9 @@ def assert_column_spec(table_name, c_spec):
         if k == 'values_in':
             assert_column_values_in(table_name, c_spec.name, v, missing_val_coding)
 
+        if (k, v) == ('is_unique', True):
+            assert_column_is_unique(table_name, c_spec.name)
+
     return
 
 
@@ -392,6 +395,33 @@ def assert_column_is_primary_key(table_name, column_name):
     if sum(pd.isnull(idx)) != 0:
         msg = "Column '%s' is the index of table '%s' but it contains missing values" \
                 % (column_name, table_name)
+        raise OrcaAssertionError(msg)
+    return
+
+
+def assert_column_is_unique(table_name, column_name):
+    """
+    Assert that column's values are unique. 
+    
+    Parameters
+    ----------
+    table_name : str
+    column_name : str
+    
+    Returns
+    -------
+    None
+    
+    """
+    assert_column_can_be_generated(table_name, column_name)
+    
+    ds = get_column_or_index(table_name, column_name)
+    
+    print(ds)
+    
+    if len(ds.unique()) != len(ds):
+        msg = "Column '%s' does not have unique values" \
+                % (column_name)
         raise OrcaAssertionError(msg)
     return
 


### PR DESCRIPTION
Adds an assertion for checking that the values in a column are unique without requiring that that column be the primary key/index.

Possible to-do: use this is_unique assertion inside of the primary_key assertion function (however, this assertion function returns a different exception message than the uniqueness check there).